### PR TITLE
Use UUID for client

### DIFF
--- a/Command/CreateClientCommand.php
+++ b/Command/CreateClientCommand.php
@@ -13,6 +13,9 @@ use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
 use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+use Ramsey\Uuid\FeatureSet;
+use Ramsey\Uuid\UuidFactory;
+use Ramsey\Uuid\Uuid;
 
 final class CreateClientCommand extends Command
 {
@@ -83,8 +86,14 @@ final class CreateClientCommand extends Command
 
     private function buildClientFromInput(InputInterface $input)
     {
-        $identifier = $input->getArgument('identifier') ?? hash('md5', random_bytes(16));
-        $secret = $input->getArgument('secret') ?? hash('sha512', random_bytes(32));
+        $identifier = $input->getArgument('identifier');
+        if ($identifier === null) {
+            $uuidFactory = new UuidFactory(new FeatureSet(false, false, false, true));
+            Uuid::setFactory($uuidFactory);
+
+            $identifier = Uuid::uuid1();
+        }
+        $secret = $input->getArgument('secret') ?? bin2hex(random_bytes(20));
 
         $client = new Client($identifier, $secret);
         $client->setActive(true);

--- a/Command/CreateClientCommand.php
+++ b/Command/CreateClientCommand.php
@@ -55,6 +55,13 @@ final class CreateClientCommand extends Command
                 'Sets allowed scope for client. Use this option multiple times to set multiple scopes.',
                 null
             )
+            ->addOption(
+                'name',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Sets the client human readable name (only used for internal reference).',
+                null
+            )
             ->addArgument(
                 'identifier',
                 InputArgument::OPTIONAL,
@@ -75,9 +82,11 @@ final class CreateClientCommand extends Command
         $this->clientManager->save($client);
         $io->success('New oAuth2 client created successfully.');
 
-        $headers = ['Identifier', 'Secret'];
+        $headers = ['Identifier', 'Secret', 'Name', 'Grants', 'Scopes'];
         $rows = [
-            [$client->getIdentifier(), $client->getSecret()],
+            [$client->getIdentifier(), $client->getSecret(),
+             $client->getName(), implode(' ', $client->getGrants()),
+             implode(' ', $client->getScopes())],
         ];
         $io->table($headers, $rows);
 
@@ -115,6 +124,8 @@ final class CreateClientCommand extends Command
             $input->getOption('scope')
         );
         $client->setScopes(...$scopes);
+
+        $client->setName($input->getOption('name'));
 
         return $client;
     }

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -34,6 +34,11 @@ class Client
      */
     private $active = true;
 
+    /**
+     * @var string
+     */
+    private $name = null;
+
     public function __construct(string $identifier, string $secret)
     {
         $this->identifier = $identifier;
@@ -117,6 +122,18 @@ class Client
     public function setActive(bool $active): self
     {
         $this->active = $active;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
 
         return $this;
     }

--- a/Resources/config/doctrine/model/Client.orm.xml
+++ b/Resources/config/doctrine/model/Client.orm.xml
@@ -3,7 +3,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
     <entity name="Trikoder\Bundle\OAuth2Bundle\Model\Client" table="oauth2_client">
-        <id name="identifier" type="string" length="32" />
+        <id name="identifier" type="string" length="36" />
         <field name="secret" type="string" length="128" />
         <field name="redirectUris" type="oauth2_redirect_uri" nullable="true" />
         <field name="grants" type="oauth2_grant" nullable="true" />

--- a/Resources/config/doctrine/model/Client.orm.xml
+++ b/Resources/config/doctrine/model/Client.orm.xml
@@ -9,5 +9,6 @@
         <field name="grants" type="oauth2_grant" nullable="true" />
         <field name="scopes" type="oauth2_scope" nullable="true" />
         <field name="active" type="boolean" />
+        <field name="name" type="string" nullable="true" />
     </entity>
 </doctrine-mapping>

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symfony/framework-bundle": "~3.4|~4.0",
         "symfony/psr-http-message-bridge": "^1.0",
         "symfony/security-bundle": "~3.4|~4.0",
-        "zendframework/zend-diactoros": "^1.7|^2.1"
+        "zendframework/zend-diactoros": "^1.7|^2.1",
+        "ramsey/uuid": "^3.8"
     },
     "require-dev": {
         "ext-timecop": "*",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "friendsofphp/php-cs-fixer": "2.14.0",
         "phpunit/phpunit": "7.5.*",
         "symfony/browser-kit": "~3.4|~4.0",
-        "symfony/phpunit-bridge": "~4.0"
+        "symfony/phpunit-bridge": "~4.0",
+        "nyholm/psr7": "^1.1"
     },
     "autoload": {
         "psr-4": { "Trikoder\\Bundle\\OAuth2Bundle\\": "" },


### PR DESCRIPTION
The client creation has been improved:

- Use uuid to identify a client.
- A name has been added to help remember what client is it.
- The default secret size has been reduced to 160 bits.